### PR TITLE
Update highlighting to catch more characters in citekeys.

### DIFF
--- a/AcademicMarkdown.tmLanguage
+++ b/AcademicMarkdown.tmLanguage
@@ -433,7 +433,7 @@
 			<key>comment</key>
 			<string>This should highlight citekeys and @refs</string>
 			<key>match</key>
-			<string>@\w+</string>
+			<string>@[\w:-]+</string>
 			<key>name</key>
 			<string>string.other.link.description.title.markdown</string>
 		</dict>


### PR DESCRIPTION
BibTeX keys exported from Zotero can contain some characters like ":" and "-". Updated the syntax definition file to catch these.

Fixes #4 