### PR TITLE
Update AcademicMarkdown.tmLanguage

### DIFF
--- a/AcademicMarkdown.tmLanguage
+++ b/AcademicMarkdown.tmLanguage
@@ -1710,7 +1710,7 @@
 		<key>fenced-shell</key>
 		<dict>
 		    <key>begin</key>
-		    <string>^(\s*[`~]{3,})(sh|shell)\s*$</string>
+		    <string>^(\s*[`~]{3,})(sh|shell|bash)\s*$</string>
 		    <key>end</key>
 		    <string>^(\1)\n</string>
 		    <key>name</key>


### PR DESCRIPTION
Fenced code labelled as "bash" now highlighted following the same rules as for "shell". Fixes minor [issue](https://github.com/mangecoeur/AcademicMarkdown/issues/12) when converting makdown to html via pandoc. Minor change from 

``` xml
        <key>fenced-shell</key>
        <dict>
            <key>begin</key>
            <string>^(\s*[`~]{3,})(sh|shell)\s*$</string>
            <key>end</key>
            <string>^(\1)\n</string>
            <key>name</key>
            <string>markup.raw.block.markdown markup.raw.block.fenced.markdown</string>
            <key>patterns</key>
            <array>
                <dict>
                    <key>include</key>
                    <string>source.shell</string>
                </dict>
            </array>
        </dict>
```

to 

``` xml
        <key>fenced-shell</key>
        <dict>
            <key>begin</key>
            <string>^(\s*[`~]{3,})(sh|shell|bash)\s*$</string>
            <key>end</key>
            <string>^(\1)\n</string>
            <key>name</key>
            <string>markup.raw.block.markdown markup.raw.block.fenced.markdown</string>
            <key>patterns</key>
            <array>
                <dict>
                    <key>include</key>
                    <string>source.shell</string>
                </dict>
            </array>
        </dict>
```

Note the inclusion of "bash" in the 4th line, and it now highlights fenced code labelled as "bash". 
