### PR TITLE
[Fixed] wrap width

### DIFF
--- a/AcademicMarkdown.sublime-settings
+++ b/AcademicMarkdown.sublime-settings
@@ -21,7 +21,7 @@
 	// Layout
 	"draw_centered": true,
 	"word_wrap": true,
-	"wrap_width": 80,
+	"wrap_width": 0,
 	"rulers": [],
 
 	// Line


### PR DESCRIPTION
If `"wrap_width": 80`, words don't transferred to the new line, example:

![wrap_width: 80](http://i.imgur.com/qiBdhiL.png)

Horizontal scrollbars — is bad practice. Better, if words to be transferred to the new line.

Thanks.